### PR TITLE
Added clean before uberwar

### DIFF
--- a/deploy-uberwar/build.boot
+++ b/deploy-uberwar/build.boot
@@ -27,6 +27,7 @@
                  :ring               {:handler hello-world.core/app}})
   (comp
     (hoplon {:optimizations :advanced})
+    (lein "clean")
     (lein "ring" "uberwar" "hello.war")))
 
 (deftask development


### PR DESCRIPTION
Considering the problems I ran into (as described on IRC), going from an earlier version of Castra to a newer, it's probably wise to add a clean step before packagaing an uberwar.
